### PR TITLE
Update FE13 item module

### DIFF
--- a/application/Modules/FE13/data/Items.json
+++ b/application/Modules/FE13/data/Items.json
@@ -121,7 +121,7 @@
 				"type": "bitflags",
 				"flags": [
 					"Summons to overworld map",
-					"Unknown Flag 2",
+					"Force animations off",
 					"Cannot be Traded in communication",
 					"Supreme Emblem",
 					"Gold",


### PR DESCRIPTION
"Unknown Flag 2" controls whether a weapon forces animations off. For example, Mend doesn't have this flag set, while Fortify does. If you set it on other weapons it will disable their animations as well.