### PR TITLE
Remove read_key_optional, also some module updates

### DIFF
--- a/application/Modules/FE13/data/Characters.json
+++ b/application/Modules/FE13/data/Characters.json
@@ -40,9 +40,9 @@
                 "type": "bitflags",
                 "flags": [
                     "Ban Battle Animations",
-                    "Experience Gain when Defeated + 20",
-                    "Experience Gain when Defeated - 10",
-                    "Unknown (Experience Gain +?)",
+                    "Experience Gain when Defeated +20",
+                    "Experience Gain when Defeated -10",
+                    "Increased Staff Experience",
                     "Marth / Lucina",
                     "Walhart",
                     "Aversa",

--- a/application/Modules/FE13/data/Items.json
+++ b/application/Modules/FE13/data/Items.json
@@ -109,7 +109,7 @@
 					"Owain only",
 					"For men",
 					"For women",
-					"Unknown Flag 1",
+					"Forged weapon",
 					"Cannot be forged",
 					"Basic weapon",
 					"Enemy only"
@@ -122,7 +122,7 @@
 				"type": "bitflags",
 				"flags": [
 					"Summons to overworld map",
-					"Unknown Flag 2",
+					"Force Map Animation",
 					"Cannot be Traded in communication",
 					"Supreme Emblem",
 					"Gold",

--- a/application/Modules/FE13/data/Person.json
+++ b/application/Modules/FE13/data/Person.json
@@ -38,9 +38,9 @@
                 "type": "bitflags",
                 "flags": [
                     "Ban Battle Animations",
-                    "Experience Gain when Defeated + 20",
-                    "Experience Gain when Defeated - 10",
-                    "Unknown (Experience Gain +?)",
+                    "Experience Gain when Defeated +20",
+                    "Experience Gain when Defeated -10",
+                    "Increased Staff Experience",
                     "Marth / Lucina",
                     "Walhart",
                     "Aversa",

--- a/application/Modules/FE14/GameData/Character.json
+++ b/application/Modules/FE14/GameData/Character.json
@@ -545,17 +545,17 @@
                 ]
             }
         },
-        "Personal Skill 1": {
+        "Personal Skill (Normal)": {
             "type": "reference",
             "target_module": "Skills",
             "target_property": "ID"
         },
-        "Personal Skill 2": {
+        "Personal Skill (Hard)": {
             "type": "reference",
             "target_module": "Skills",
             "target_property": "ID"
         },
-        "Personal Skill 3": {
+        "Personal Skill (Lunatic)": {
             "type": "reference",
             "target_module": "Skills",
             "target_property": "ID"

--- a/application/Modules/FE14/GameData/Class.json
+++ b/application/Modules/FE14/GameData/Class.json
@@ -204,14 +204,14 @@
                 "type": "stats"
             }
         },
-        "Growths": {
+        "Player Growths": {
             "type": "buffer",
             "length": 8,
             "editor": {
                 "type": "stats"
             }
         },
-        "Unknown Stats": {
+        "Enemy Growths": {
             "type": "buffer",
             "length": 8,
             "editor": {

--- a/application/Modules/FE14/GameData/Class.json
+++ b/application/Modules/FE14/GameData/Class.json
@@ -235,38 +235,38 @@
         "Max Sword /Katana Wep EXP": {
             "type": "u8"
         },
-		"Max Lance / Naginata Wep EXP": {
+        "Max Lance / Naginata Wep EXP": {
             "type": "u8"
         },
-		"Max Axe / Club Wep EXP": {
+        "Max Axe / Club Wep EXP": {
             "type": "u8"
         },
-		"Max Dagger / Shuriken Wep EXP": {
+        "Max Dagger / Shuriken Wep EXP": {
             "type": "u8"
         },
-		"Max Bow / Yumi Wep EXP": {
+        "Max Bow / Yumi Wep EXP": {
             "type": "u8"
         },
-		"Max Tome / Scroll Wep EXP": {
+        "Max Tome / Scroll Wep EXP": {
             "type": "u8"
         },
-		"Max Staff / Rod Wep EXP": {
+        "Max Staff / Rod Wep EXP": {
             "type": "u8"
         },
-		"Max Stone Wep EXP": {
+        "Max Stone Wep EXP": {
             "type": "u8"
         },
         "Hit": {
-            "type": "u16"
+            "type": "i16"
         },
         "Crit": {
-            "type": "u16"
+            "type": "i16"
         },
         "Avoid": {
-            "type": "u16"
+            "type": "i16"
         },
         "Dodge": {
-            "type": "u16"
+            "type": "i16"
         },
         "Skill 1": {
             "type": "reference",
@@ -299,9 +299,9 @@
             "editor": {
                 "type": "combobox",
                 "data": "FE14SmokeSize"
-			}
+            }
         },
-		"Extra Flags": {
+        "Extra Flags": {
             "type": "u8",
             "editor": {
                 "type": "bitflags",
@@ -350,10 +350,10 @@
         },
         "Origin": {
             "type": "u8",
-			"editor": {
+            "editor": {
                 "type": "combobox",
                 "data": "FE14ClassOrigin"
-			}
+            }
         },
         "Unknown (2)": {
             "type": "buffer",

--- a/application/Modules/FE14/GameData/Person.json
+++ b/application/Modules/FE14/GameData/Person.json
@@ -542,17 +542,17 @@
                 ]
             }
         },
-        "Personal Skill 1": {
+        "Personal Skill (Normal)": {
             "type": "reference",
             "target_module": "Skills",
             "target_property": "ID"
         },
-        "Personal Skill 2": {
+        "Personal Skill (Hard)": {
             "type": "reference",
             "target_module": "Skills",
             "target_property": "ID"
         },
-        "Personal Skill 3": {
+        "Personal Skill (Lunatic)": {
             "type": "reference",
             "target_module": "Skills",
             "target_property": "ID"

--- a/application/Modules/FE14/GameData/Skill.json
+++ b/application/Modules/FE14/GameData/Skill.json
@@ -40,7 +40,7 @@
             "type": "u16",
             "id": true
         },
-        "Unknown": {
+        "Sort Order": {
             "type": "u16"
         },
         "Icon ID": {

--- a/application/module/count.py
+++ b/application/module/count.py
@@ -2,11 +2,10 @@ from abc import ABC, abstractmethod
 
 from core.bin_streams import BinArchiveWriter, BinArchiveReader
 from module.location import location_strategy_from_json
-from utils.checked_json import read_key_optional
 
 
 def count_strategy_from_json(js):
-    count_type = read_key_optional(js, "count_type", "simple")
+    count_type = js.get("count_type", "simple")
     if count_type == "simple":
         return SimpleCountStrategy(js)
     elif count_type == "null_terminated":

--- a/application/module/location.py
+++ b/application/module/location.py
@@ -2,7 +2,6 @@ import logging
 from abc import ABC, abstractmethod
 
 from core.bin_streams import BinArchiveReader
-from utils.checked_json import read_key_optional
 
 
 def location_strategy_from_json(js):
@@ -40,7 +39,7 @@ class DynamicLocationStrategy(LocationStrategy):
     def __init__(self, js):
         super().__init__()
         self.address = js["address"]
-        self.offset = read_key_optional(js, "offset", 0)
+        self.offset = js.get("offset", 0)
 
     def read_base_address(self, archive) -> int:
         reader = BinArchiveReader(archive, self.address)
@@ -49,7 +48,7 @@ class DynamicLocationStrategy(LocationStrategy):
 
 class SOVSkipLocationStrategy(LocationStrategy):
     def __init__(self, js):
-        self.offset = read_key_optional(js, "offset", 0)
+        self.offset = js.get("offset", 0)
 
     def read_base_address(self, archive) -> int:
         reader = BinArchiveReader(archive)
@@ -60,7 +59,7 @@ class SOVSkipLocationStrategy(LocationStrategy):
 class DynamicSOVSkipLocationStrategy(LocationStrategy):
     def __init__(self, js):
         self.offset_to_pointer = js["offset_to_pointer"]
-        self.offset = read_key_optional(js, "offset", 0)
+        self.offset = js.get("offset", 0)
 
     def read_base_address(self, archive) -> int:
         reader = BinArchiveReader(archive)
@@ -72,7 +71,7 @@ class DynamicSOVSkipLocationStrategy(LocationStrategy):
 class FromMappedLocationStrategy(LocationStrategy):
     def __init__(self, js):
         self.mapped_value = js["mapped_value"]
-        self.offset = read_key_optional(js, "offset", 0)
+        self.offset = js.get("offset", 0)
 
     def read_base_address(self, archive) -> int:
         return archive.addr_of_mapped_pointer(self.mapped_value) + self.offset

--- a/application/module/module.py
+++ b/application/module/module.py
@@ -3,13 +3,12 @@ from copy import copy
 
 from module.location import location_strategy_from_json
 from module.properties.property_container import PropertyContainer
-from utils.checked_json import read_key_optional
 
 
 class Module(ABC):
     def __init__(self, js):
         self.name = js["name"]
-        self.unique = read_key_optional(js, "unique", False)
+        self.unique = js.get("unique", False)
         if self.unique:
             self.file = js["file"]
         else:

--- a/application/module/properties/abstract_property.py
+++ b/application/module/properties/abstract_property.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from PySide2.QtWidgets import QWidget
 
-from utils.checked_json import read_key_optional
 
 
 class AbstractProperty(ABC):
@@ -25,7 +24,7 @@ class AbstractProperty(ABC):
         result = cls._from_json(name, json)
         if result.is_id:
             result.is_disabled = True
-        result.is_disabled = read_key_optional(json, "disabled", result.is_disabled)
+        result.is_disabled = json.get("disabled", result.is_disabled)
         return result
 
     @classmethod

--- a/application/module/properties/i32_property.py
+++ b/application/module/properties/i32_property.py
@@ -1,7 +1,6 @@
 from PySide2.QtWidgets import QWidget
 from ui.widgets.data_combo_box import DataComboBox
 from ui.widgets.integer_property_spin_box import IntegerPropertySpinBox
-from utils.checked_json import read_key_optional
 from .abstract_property import AbstractProperty
 
 
@@ -17,7 +16,7 @@ class I32Property(AbstractProperty):
     @classmethod
     def _from_json(cls, name, json):
         result = I32Property(name)
-        result.is_id = read_key_optional(json, "id", False)
+        result.is_id = json.get("id", False)
         if "editor" in json:
             cls._parse_editor(result, json["editor"])
         return result

--- a/application/module/properties/mapped_property.py
+++ b/application/module/properties/mapped_property.py
@@ -1,5 +1,4 @@
 from PySide2.QtWidgets import QWidget
-from utils.checked_json import read_key_optional
 from .abstract_property import AbstractProperty
 from ui.widgets.string_property_line_edit import StringPropertyLineEdit
 
@@ -24,9 +23,9 @@ class MappedProperty(AbstractProperty):
     @classmethod
     def _from_json(cls, name, json):
         result = MappedProperty(name)
-        result.is_display = read_key_optional(json, "display", False)
-        result.is_fallback_display = read_key_optional(json, "fallback_display", False)
-        result.linked_property = read_key_optional(json, "linked_property", None)
+        result.is_display = json.get("display", False)
+        result.is_fallback_display = json.get("fallback_display", False)
+        result.linked_property = json.get("linked_property", None)
         return result
 
     def read(self, reader):

--- a/application/module/properties/message_property.py
+++ b/application/module/properties/message_property.py
@@ -2,7 +2,6 @@ from PySide2.QtWidgets import QWidget
 from module.properties.abstract_property import AbstractProperty
 from services import service_locator
 from ui.widgets.message_property_editor import MessagePropertyEditor
-from utils.checked_json import read_key_optional
 
 
 class MessageProperty(AbstractProperty):
@@ -38,8 +37,8 @@ class MessageProperty(AbstractProperty):
     def _from_json(cls, name, json):
         target_message_archive = json["file"]
         result = MessageProperty(name, target_message_archive)
-        result.is_display = read_key_optional(json, "display", False)
-        result.is_fallback_display = read_key_optional(json, "fallback_display", False)
+        result.is_display = json.get("display", False)
+        result.is_fallback_display = json.get("fallback_display", False)
         return result
 
     def read(self, reader):

--- a/application/module/properties/reference_property.py
+++ b/application/module/properties/reference_property.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from PySide2.QtWidgets import QWidget
 from services.service_locator import locator
-from utils.checked_json import read_key_optional
 from .abstract_property import AbstractProperty
 from ui.widgets.reference_property_editor import ReferencePropertyEditor
 
@@ -25,8 +24,8 @@ class ReferenceProperty(AbstractProperty):
         target_module = json["target_module"]
         target_property = json["target_property"]
         result = ReferenceProperty(name, target_module, target_property)
-        result.is_display = read_key_optional(json, "display", False)
-        result.is_fallback_display = read_key_optional(json, "fallback_display", False)
+        result.is_display = json.get("display", False)
+        result.is_fallback_display = json.get("fallback_display", False)
         return result
 
     def read(self, reader):

--- a/application/module/properties/string_property.py
+++ b/application/module/properties/string_property.py
@@ -1,5 +1,4 @@
 from PySide2.QtWidgets import QWidget
-from utils.checked_json import read_key_optional
 from .abstract_property import AbstractProperty
 from ui.widgets.string_property_line_edit import StringPropertyLineEdit
 
@@ -22,9 +21,9 @@ class StringProperty(AbstractProperty):
     @classmethod
     def _from_json(cls, name, json):
         result = StringProperty(name)
-        result.is_display = read_key_optional(json, "display", False)
-        result.is_fallback_display = read_key_optional(json, "fallback_display", False)
-        result.linked_property = read_key_optional(json, "linked_property", None)
+        result.is_display = json.get("display", False)
+        result.is_fallback_display = json.get("fallback_display", False)
+        result.linked_property = json.get("linked_property", None)
         return result
 
     def read(self, reader):

--- a/application/module/properties/u16_property.py
+++ b/application/module/properties/u16_property.py
@@ -1,7 +1,6 @@
 from PySide2.QtWidgets import QWidget
 from ui.widgets.data_combo_box import DataComboBox
 from ui.widgets.integer_property_spin_box import IntegerPropertySpinBox
-from utils.checked_json import read_key_optional
 from .abstract_property import AbstractProperty
 
 
@@ -17,7 +16,7 @@ class U16Property(AbstractProperty):
     @classmethod
     def _from_json(cls, name, json):
         result = U16Property(name)
-        result.is_id = read_key_optional(json, "id", False)
+        result.is_id = json.get("id", False)
         if "editor" in json:
             cls._parse_editor(result, json["editor"])
         return result
@@ -26,7 +25,7 @@ class U16Property(AbstractProperty):
     def _parse_editor(prop, json):
         editor_type = json["type"]
         if editor_type == "spinbox":
-            hex = read_key_optional(json, "hex", False)
+            hex = json.get("hex", False)
             prop.editor_factory = lambda: IntegerPropertySpinBox(prop.name, 0, 65535, hex)
         elif editor_type == "combobox":
             data_type = json["data"]

--- a/application/module/properties/u8_property.py
+++ b/application/module/properties/u8_property.py
@@ -1,7 +1,6 @@
 from PySide2.QtWidgets import QWidget
 from ui.widgets.bitflags_editor import BitflagsEditor
 from ui.widgets.data_combo_box import DataComboBox
-from utils.checked_json import read_key_optional
 from .abstract_property import AbstractProperty
 from ui.widgets.integer_property_spin_box import IntegerPropertySpinBox
 
@@ -18,7 +17,7 @@ class U8Property(AbstractProperty):
     @classmethod
     def _from_json(cls, name, json):
         result = U8Property(name)
-        result.is_id = read_key_optional(json, "id", False)
+        result.is_id = json.get("id", False)
         if "editor" in json:
             cls._parse_editor(result, json["editor"])
         return result
@@ -27,7 +26,7 @@ class U8Property(AbstractProperty):
     def _parse_editor(prop, json):
         editor_type = json["type"]
         if editor_type == "spinbox":
-            hex = read_key_optional(json, "hex", False)
+            hex = json.get("hex", False)
             prop.editor_factory = lambda: IntegerPropertySpinBox(prop.name, 0, 255, hex)
         elif editor_type == "combobox":
             data_type = json["data"]

--- a/application/module/table_module.py
+++ b/application/module/table_module.py
@@ -3,7 +3,6 @@ from core.bin_streams import BinArchiveWriter, BinArchiveReader
 from model.qt.module_entry_model import ModuleEntryModel
 from module.count import count_strategy_from_json
 from module.module import Module
-from utils.checked_json import read_key_optional
 
 
 class TableModule(Module):
@@ -13,7 +12,7 @@ class TableModule(Module):
         self.count_strategy = count_strategy_from_json(js["count"])
         self.entries = []
         self.entries_model: ModuleEntryModel = ModuleEntryModel(self)
-        self.disable_add_remove = read_key_optional(js, "disable_add_remove", False)
+        self.disable_add_remove = js.get("disable_add_remove", False)
 
     def find_base_address_for_element(self, element):
         if not self.archive:

--- a/application/utils/checked_json.py
+++ b/application/utils/checked_json.py
@@ -1,5 +1,0 @@
-def read_key_optional(js, key, default=None):
-    if key in js:
-        return js[key]
-    return default
-


### PR DESCRIPTION
This is really two sets of changes:
- a bunch of fairly mundane module label updates
- I noticed that read_key_optional was functionally identical to [dict.get](https://docs.python.org/3/library/stdtypes.html#dict.get) and replaced all uses of it with the standard method.