### PR TITLE
Use log level DEBUG to make logs filterable

### DIFF
--- a/application/Modules/FE14/GameData/Item.json
+++ b/application/Modules/FE14/GameData/Item.json
@@ -279,7 +279,10 @@
         },
         "Extra data": {
             "type": "buffer",
-            "length": 8
+            "length": 8,
+            "editor": {
+                "type": "togglestats"
+            }
         },
         "Forge table index": {
             "type": "u8"

--- a/application/Modules/FE14/GameData/Person.json
+++ b/application/Modules/FE14/GameData/Person.json
@@ -378,11 +378,7 @@
             }
         },
         "Army ID": {
-            "type": "u8",
-            "editor": {
-                "type": "spinbox",
-                "hex": true
-            }
+            "type": "u8"
         },
         "Replace ID": {
             "type": "reference",

--- a/application/main.py
+++ b/application/main.py
@@ -1,5 +1,5 @@
 import logging
-logging.basicConfig(handlers=[logging.FileHandler('paragon.log', 'w', 'utf-8')], level=logging.INFO)
+logging.basicConfig(handlers=[logging.FileHandler('paragon.log', 'w', 'utf-8')], level=logging.DEBUG)
 import sys
 from PySide2.QtWidgets import QApplication
 from core.state_machine import StateMachine

--- a/application/module/properties/buffer_property.py
+++ b/application/module/properties/buffer_property.py
@@ -1,4 +1,5 @@
 from ui.widgets.stats_editor import StatsEditor
+from ui.widgets.toggle_stats_editor import ToggleStatsEditor
 from .abstract_property import AbstractProperty
 from PySide2.QtWidgets import QWidget
 from ui.widgets.buffer_property_line_edit import BufferPropertyLineEdit
@@ -36,6 +37,10 @@ class BufferProperty(AbstractProperty):
             if prop.length != 8:
                 raise IndexError
             prop.editor_factory = lambda: StatsEditor(prop.name)
+        elif editor_type == "togglestats":
+            if prop.length != 8:
+                raise IndexError
+            prop.editor_factory = lambda: ToggleStatsEditor(prop.name)
 
     def read(self, reader):
         self.value = reader.read_bytes(self.length)

--- a/application/module/properties/property_container.py
+++ b/application/module/properties/property_container.py
@@ -51,7 +51,7 @@ class PropertyContainer:
 
         con = PropertyContainer()
         for key in js:
-            logging.info("Parsing property %s" % key)
+            logging.debug("Parsing property %s" % key)
             property_config = js[key]
             property_type = properties[property_config["type"]]
             prop = property_type.from_json(key, property_config)

--- a/application/services/open_files_service.py
+++ b/application/services/open_files_service.py
@@ -48,12 +48,11 @@ class OpenFilesService:
         return None
 
     def open(self, path_in_rom):
-        logging.info("Opening " + path_in_rom)
         if path_in_rom in self.open_files:
-            logging.info("Found " + path_in_rom + " in cache.")
+            logging.debug("Found " + path_in_rom + " in cache.")
             return self.open_files[path_in_rom].file
 
-        logging.info(path_in_rom + " was not in the cache. Reading from filesystem...")
+        logging.debug(path_in_rom + " was not in the cache. Reading from filesystem...")
         archive = self._try_open_bin("/" + path_in_rom)
 
         logging.info("Successfully read " + path_in_rom + " from filesystem.")
@@ -84,9 +83,9 @@ class OpenFilesService:
         self.open_files[path_in_rom].dirty = True
 
     def open_message_archive(self, path_in_rom):
-        logging.info("Opening message archive at path %s" % path_in_rom)
+        logging.debug("Opening message archive at path %s" % path_in_rom)
         if path_in_rom in self.open_message_archives:
-            logging.info("Found %s in cache." % path_in_rom)
+            logging.debug("Found %s in cache." % path_in_rom)
             return self.open_message_archives[path_in_rom]
 
         archive = self._try_open_bin("/" + path_in_rom, localized=True)

--- a/application/ui/widgets/toggle_stats_editor.py
+++ b/application/ui/widgets/toggle_stats_editor.py
@@ -1,0 +1,102 @@
+import struct
+from PySide2.QtWidgets import QSpinBox, QLabel, QFormLayout, QGroupBox, QPushButton, QLineEdit, QWidget
+from model.project import Game
+from services import service_locator
+from ui.widgets.property_widget import PropertyWidget
+from .stats_editor import EDITOR_LABELS, EDITOR_LABELS_SOV
+
+class ToggleStatsEditor (QGroupBox, PropertyWidget):
+    def __init__(self, target_property_name):
+        QGroupBox.__init__(self)
+        PropertyWidget.__init__(self, target_property_name)
+        self.main_layout = QFormLayout(self)
+
+        self.buffer_editor = QLineEdit()
+        self.buffer_editor.editingFinished.connect(self._on_buffer_edit)
+        self.buffer_editor.setInputMask("HH HH HH HH HH HH HH HH;0")
+        self.buffer_editor.setVisible(False)
+
+        self.stats_layout = QFormLayout()
+        self.stats_layout.setContentsMargins(0, 0, 0, 0)
+        self.stat_editors = [
+            QSpinBox(),
+            QSpinBox(),
+            QSpinBox(),
+            QSpinBox(),
+            QSpinBox(),
+            QSpinBox(),
+            QSpinBox(),
+            QSpinBox()
+        ]
+        labels = self._get_labels_for_project()
+        for i in range(0, 8):
+            editor = self.stat_editors[i]
+            editor.setRange(-128, 127)
+            self.stats_layout.addRow(QLabel(labels[i]), editor)
+
+        self.stats_widget = QWidget()
+        self.stats_widget.setLayout(self.stats_layout)
+
+        self.editor_toggle = QPushButton("Toggle Stats/Hex Editor")
+        self.editor_toggle.clicked.connect(self._on_editor_toggle)
+
+        self.main_layout.addRow(self.editor_toggle)
+        self.main_layout.addRow(self.stats_widget)
+
+        self.stat_editors[0].valueChanged.connect(lambda: self._on_stat_edit(0))
+        self.stat_editors[1].valueChanged.connect(lambda: self._on_stat_edit(1))
+        self.stat_editors[2].valueChanged.connect(lambda: self._on_stat_edit(2))
+        self.stat_editors[3].valueChanged.connect(lambda: self._on_stat_edit(3))
+        self.stat_editors[4].valueChanged.connect(lambda: self._on_stat_edit(4))
+        self.stat_editors[5].valueChanged.connect(lambda: self._on_stat_edit(5))
+        self.stat_editors[6].valueChanged.connect(lambda: self._on_stat_edit(6))
+        self.stat_editors[7].valueChanged.connect(lambda: self._on_stat_edit(7))
+
+    @staticmethod
+    def _get_labels_for_project():
+        driver = service_locator.locator.get_scoped("Driver")
+        project = driver.get_project()
+        if project.game == Game.FE15.value:
+            return EDITOR_LABELS_SOV
+        else:
+            return EDITOR_LABELS
+
+    def _on_editor_toggle(self):
+        show_stats = self.buffer_editor.isVisible()
+        self.buffer_editor.setVisible(not show_stats)
+        self.stats_widget.setVisible(show_stats)
+        self.main_layout.takeAt(1)
+        if show_stats:
+            self.main_layout.addRow(self.stats_widget)
+        else:
+            self.main_layout.addRow(self.buffer_editor)
+
+    def _on_buffer_edit(self):
+        if self.target:
+            buffer = self._get_target_value()
+            split_text = self.buffer_editor.displayText().split()
+            for j in range(8):
+                buffer[j] = int(split_text[j], 16)
+            self._on_target_changed()
+
+    def _on_stat_edit(self, index):
+        if self.target:
+            buffer = self._get_target_value()
+            value = self.stat_editors[index].value()
+            binary_value = struct.pack("b", value)
+            unsigned_value = int(struct.unpack("B", binary_value)[0])
+            buffer[index] = unsigned_value
+            self._on_target_changed()
+
+    def _on_target_changed(self):
+        if self.target:
+            buffer = self._get_target_value()
+            self.buffer_editor.setText(" ".join("%02x" % x for x in buffer))
+            for i in range(0, 8):
+                binary_value = struct.pack("B", buffer[i])
+                value = int(struct.unpack("b", binary_value)[0])
+                self.stat_editors[i].setValue(value)
+        else:
+            self.buffer_editor.setText("00 00 00 00 00 00 00 00")
+            for editor in self.stat_editors:
+                editor.setValue(0)


### PR DESCRIPTION
Sets some of the noisiest log messages to level DEBUG so that only the corresponding reads from filesystem get emitted at level INFO, but also set the default logging level to DEBUG so that they're still saved to paragon.log by default.

I usually run with logging to stderr (= my terminal), which 9b7936c30ddd6107500146a280670ea619fa2cbc made extremely noisy with literally thousands of lines of "Found m/GameData.bin.lz in cache." and "Opening message archive at path m/GameData.bin.lz", drowning out useful diagnostics.

I also put the "Parsing property" on level DEBUG because those have pushed JSON parse exceptions off my screen in the past.