### PR TITLE
Added cgfx and ctpk support for Awakening texture files + refactoring

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -4,18 +4,76 @@ use encoding_rs::SHIFT_JIS;
 
 const HEADER_SIZE : u32 = 0x20;
 
+pub struct Arc {
+    pub header: Header,
+    pub files: Vec<File>,
+}
+
+impl Arc {
+    pub fn new(archive: &[u8]) -> Result<Arc> {
+        let mut reader = Cursor::new(archive);
+        let header = Header::new(&mut reader)?;
+    
+        // Initialize array to store files
+        let mut files: Vec<File> = Vec::new();
+        for count in 0..header.file_count {
+            // Get metadata
+            let metadata = Metadata::new(&header, &mut reader, count)?;
+    
+            // Get Filename
+            reader.seek(SeekFrom::Start(metadata.filename_ptr as u64))?;
+            let mut filename_buffer: Vec<u8> = Vec::new();
+            reader.read_until(0x0, &mut filename_buffer)?;
+            filename_buffer.pop(); // Don't store the null terminator.
+            let (result, _, errors) = SHIFT_JIS.decode(filename_buffer.as_slice());
+            if errors {
+                return Err(Error::new(ErrorKind::Other, "Failed to decode shift-jis string."))
+            }
+            let filename = result.into();
+    
+            // Get file bytes
+            reader.seek(SeekFrom::Start(metadata.file_ptr as u64))?;
+            let mut bytes: Vec<u8> = vec![0; metadata.file_length as usize];
+            reader.read_exact(&mut bytes)?;
+    
+            // Now store the files
+            files.push(File { filename, bytes });
+        }
+        Ok(Arc {
+            header,
+            files
+        })
+    }
+}
+
 pub struct File {
     pub filename: String,
     pub bytes: Vec<u8>,
 }
 
-struct Header {
+pub struct Header {
     pub file_archive_length: u32,
     pub metadata_ptr_table_offset: u32,
     pub file_count: u32,
     pub is_awakening: bool,
 }
 
+impl Header {
+    fn new(reader: &mut Cursor<&[u8]>) -> Result<Header> {
+        let file_archive_length = reader.read_u32::<LittleEndian>()?;
+        let metadata_ptr_table_offset = reader.read_u32::<LittleEndian>()? + HEADER_SIZE;
+        let file_count = reader.read_u32::<LittleEndian>()?;
+    
+        reader.seek(SeekFrom::Start(0x20))?;
+        let is_awakening_check= reader.read_u8()?;  // Not really a flag; just that Fates uses a 128 byte-alignment struct
+        Ok(Header {
+            file_archive_length,
+            metadata_ptr_table_offset,
+            file_count,
+            is_awakening: is_awakening_check != 0,
+        })
+    }
+}
 struct Metadata {
     pub filename_ptr: u32,
     pub index: u32,
@@ -23,66 +81,21 @@ struct Metadata {
     pub file_ptr: u32,
 }
 
-pub fn unpack(archive: &[u8]) -> Result<Vec<File>> {
-    let mut reader = Cursor::new(archive);
-    let header = read_header(&mut reader)?;
-
-    // Initialize array to store files
-    let mut files: Vec<File> = Vec::new();
-    for count in 0..header.file_count {
-        // Get metadata
-        let metadata = read_metadata(&header, &mut reader, count)?;
-
-        // Get Filename
-        reader.seek(SeekFrom::Start(metadata.filename_ptr as u64))?;
-        let mut filename_buffer: Vec<u8> = Vec::new();
-        reader.read_until(0x0, &mut filename_buffer)?;
-        filename_buffer.pop(); // Don't store the null terminator.
-        let (result, _, errors) = SHIFT_JIS.decode(filename_buffer.as_slice());
-        if errors {
-            return Err(Error::new(ErrorKind::Other, "Failed to decode shift-jis string."))
-        }
-        let filename = result.into();
-
-        // Get file bytes
-        reader.seek(SeekFrom::Start(metadata.file_ptr as u64))?;
-        let mut bytes: Vec<u8> = vec![0; metadata.file_length as usize];
-        reader.read_exact(&mut bytes)?;
-
-        // Now store the files
-        files.push(File { filename, bytes });
+impl Metadata {
+    fn new(header: &Header, reader: &mut Cursor<&[u8]>, count: u32) -> Result<Metadata> {
+        reader.seek(SeekFrom::Start((header.metadata_ptr_table_offset + 4 * count) as u64))?;
+        let metadata_pointer = reader.read_u32::<LittleEndian>()? + HEADER_SIZE;
+        reader.seek(SeekFrom::Start(metadata_pointer as u64))?;
+    
+        let filename_ptr = reader.read_u32::<LittleEndian>()? + HEADER_SIZE;
+        let index = reader.read_u32::<LittleEndian>()?; // Not necessary
+        let file_length = reader.read_u32::<LittleEndian>()?;
+        let file_ptr = if header.is_awakening {reader.read_u32::<LittleEndian>()? + 0x20} else {reader.read_u32::<LittleEndian>()? + 0x80};
+        Ok(Metadata {
+            filename_ptr,
+            index,
+            file_length,
+            file_ptr,
+        })
     }
-    Ok(files)
-}
-
-fn read_header(reader: &mut Cursor<&[u8]>) -> Result<Header> {
-    let file_archive_length = reader.read_u32::<LittleEndian>()?;
-    let metadata_ptr_table_offset = reader.read_u32::<LittleEndian>()? + HEADER_SIZE;
-    let file_count = reader.read_u32::<LittleEndian>()?;
-
-    reader.seek(SeekFrom::Start(0x20))?;
-    let is_awakening_check= reader.read_u8()?;  // Not really a flag; just that Fates uses a 128 byte-alignment struct
-    Ok(Header {
-        file_archive_length,
-        metadata_ptr_table_offset,
-        file_count,
-        is_awakening: is_awakening_check != 0,
-    })
-}
-
-fn read_metadata(header: &Header, reader: &mut Cursor<&[u8]>, count: u32) -> Result<Metadata> {
-    reader.seek(SeekFrom::Start((header.metadata_ptr_table_offset + 4 * count) as u64))?;
-    let metadata_pointer = reader.read_u32::<LittleEndian>()? + HEADER_SIZE;
-    reader.seek(SeekFrom::Start(metadata_pointer as u64))?;
-
-    let filename_ptr = reader.read_u32::<LittleEndian>()? + HEADER_SIZE;
-    let index = reader.read_u32::<LittleEndian>()?; // Not necessary
-    let file_length = reader.read_u32::<LittleEndian>()?;
-    let file_ptr = if header.is_awakening {reader.read_u32::<LittleEndian>()? + 0x20} else {reader.read_u32::<LittleEndian>()? + 0x80};
-    Ok(Metadata {
-        filename_ptr,
-        index,
-        file_length,
-        file_ptr,
-    })
 }

--- a/src/bch.rs
+++ b/src/bch.rs
@@ -113,21 +113,13 @@ fn read_header(reader: &mut Cursor<&[u8]>) -> Result<Header> {
     let strings_address = reader.read_u32::<LittleEndian>()?;
     let commands_address = reader.read_u32::<LittleEndian>()?;
     let raw_data_address = reader.read_u32::<LittleEndian>()?;
-<<<<<<< HEAD
     let raw_ext_address = if backward_compatibility > 20 {reader.read_u32::<LittleEndian>()?} else {0};
-=======
-    let raw_ext_address = if backward_compatibility {reader.read_u32::<LittleEndian>()?} else {0};
->>>>>>> b7fb863... Inline if/else for bch
     let relocation_address = reader.read_u32::<LittleEndian>()?;
     let contents_length = reader.read_u32::<LittleEndian>()?;
     let strings_length = reader.read_u32::<LittleEndian>()?;
     let commands_length = reader.read_u32::<LittleEndian>()?;
     let raw_data_length = reader.read_u32::<LittleEndian>()?;
-<<<<<<< HEAD
     let raw_ext_length = if backward_compatibility > 20 {reader.read_u32::<LittleEndian>()?} else {0};
-=======
-    let raw_ext_length = if backward_compatibility > 0x20 {reader.read_u32::<LittleEndian>()?} else {0};
->>>>>>> b7fb863... Inline if/else for bch
     let relocation_length = reader.read_u32::<LittleEndian>()?;
     let uninit_data_length = reader.read_u32::<LittleEndian>()?;
     let uninit_commands_length = reader.read_u32::<LittleEndian>()?;

--- a/src/bch.rs
+++ b/src/bch.rs
@@ -1,20 +1,9 @@
-use crate::etc1;
+use crate::texture_decoder;
 use byteorder::{LittleEndian, ReadBytesExt};
 use encoding_rs::UTF_8;
 use pyo3::prelude::*;
 use std::io::prelude::*;
 use std::io::{Cursor, Error, ErrorKind, Read, Result, Seek, SeekFrom};
-
-static CONVERT_5_TO_8: &'static [u8] = &[
-    0x00, 0x08, 0x10, 0x18, 0x20, 0x29, 0x31, 0x39, 0x41, 0x4A, 0x52, 0x5A, 0x62, 0x6A, 0x73, 0x7B,
-    0x83, 0x8B, 0x94, 0x9C, 0xA4, 0xAC, 0xB4, 0xBD, 0xC5, 0xCD, 0xD5, 0xDE, 0xE6, 0xEE, 0xF6, 0xFF,
-];
-
-static TILE_ORDER: &'static [u8] = &[
-    0, 1, 8, 9, 2, 3, 10, 11, 16, 17, 24, 25, 18, 19, 26, 27, 4, 5, 12, 13, 6, 7, 14, 15, 20, 21,
-    28, 29, 22, 23, 30, 31, 32, 33, 40, 41, 34, 35, 42, 43, 48, 49, 56, 57, 50, 51, 58, 59, 36, 37,
-    44, 45, 38, 39, 46, 47, 52, 53, 60, 61, 54, 55, 62, 63,
-];
 
 #[allow(dead_code)]
 pub struct Header {
@@ -49,153 +38,6 @@ pub struct Texture {
     pub width: usize,
     pub pixel_data: Vec<u8>,
     pub pixel_format: u32,
-}
-
-fn decode_color(value: u32, format: u32) -> Vec<u8> {
-    let mut color: Vec<u8> = vec![0, 0, 0, 0];
-    match format {
-        0 => {
-            // RGBA8
-            color[0] = ((value >> 24) & 0xFF) as u8;
-            color[1] = ((value >> 16) & 0xFF) as u8;
-            color[2] = ((value >> 8) & 0xFF) as u8;
-            color[3] = (value & 0xFF) as u8;
-        }
-        1 => {
-            // RGB8
-            color[0] = ((value >> 16) & 0xFF) as u8;
-            color[1] = ((value >> 8) & 0xFF) as u8;
-            color[2] = (value & 0xFF) as u8;
-            color[3] = 0xFF;
-        }
-        2 => {
-            // RGB 5551
-            color[0] = CONVERT_5_TO_8[((value >> 11) & 0x1F) as usize];
-            color[1] = CONVERT_5_TO_8[((value >> 6) & 0x1F) as usize];
-            color[2] = CONVERT_5_TO_8[((value >> 1) & 0x1F) as usize];
-            color[3] = if value & 1 == 1 { 0xFF } else { 0 };
-        }
-        3 => {
-            // RGB565
-            color[0] = CONVERT_5_TO_8[((value >> 11) & 0x1F) as usize];
-            color[1] = (((value >> 5) & 0x3F) * 4) as u8;
-            color[2] = CONVERT_5_TO_8[(value & 0x1F) as usize];
-            color[3] = 0xFF;
-        }
-        4 => {
-            // RGBA4
-            let r = (value >> 12) & 0xF;
-            let g = (value >> 8) & 0xF;
-            let b = (value >> 4) & 0xF;
-            let a = value & 0xF;
-            color[0] = (r | (r << 4)) as u8;
-            color[1] = (g | (g << 4)) as u8;
-            color[2] = (b | (b << 4)) as u8;
-            color[3] = (a | (a << 4)) as u8;
-        }
-        5 => {
-            // LA8
-            let red = ((value >> 8) & 0xFF) as u8;
-            color[0] = red;
-            color[1] = red;
-            color[2] = red;
-            color[3] = (value & 0xFF) as u8;
-        }
-        6 => {
-            // HILO8
-            let red = (value >> 8) as u8;
-            color[0] = red;
-            color[1] = red;
-            color[2] = red;
-            color[3] = 0xFF;
-        }
-        7 => {
-            // L8
-            color[0] = value as u8;
-            color[1] = value as u8;
-            color[2] = value as u8;
-            color[3] = 0xFF;
-        }
-        8 => {
-            // A8
-            color[0] = 0xFF;
-            color[1] = 0xFF;
-            color[2] = 0xFF;
-            color[3] = value as u8;
-        }
-        9 => {
-            // LA4
-            let red = (value >> 4) as u8;
-            color[0] = red;
-            color[1] = red;
-            color[2] = red;
-            color[3] = (value & 0xF) as u8;
-        }
-        10 => {
-            // L4
-            let red = (value * 0x11) as u8;
-            color[0] = red;
-            color[1] = red;
-            color[2] = red;
-            color[3] = 0xFF;
-        }
-        11 => {
-            // A4
-            color[0] = 0xFF;
-            color[1] = 0xFF;
-            color[2] = 0xFF;
-            color[3] = (value * 0x11) as u8;
-        }
-        _ => {}
-    }
-    color
-}
-
-fn decode_rgba_pixel_data(
-    data: &[u8],
-    width: usize,
-    height: usize,
-    format: u32,
-) -> Result<Vec<u8>> {
-    let num_pixels = width * height;
-    let mut bmp: Vec<u8> = Vec::new();
-    bmp.resize(4 * num_pixels, 0);
-    let mut cursor = Cursor::new(data);
-
-    for tile_y in 0..height / 8 {
-        for tile_x in 0..width / 8 {
-            for pixel in 0..64 {
-                let x = (TILE_ORDER[pixel] % 8) as usize;
-                let y = (TILE_ORDER[pixel] as usize - x) / 8;
-                let output_index = (tile_x * 8 + x + ((tile_y * 8 + y) * width)) * 4;
-            
-                let color = match format {
-                    0 => decode_color(cursor.read_u32::<LittleEndian>()?, format),
-                    1 => {
-                        let value = cursor.read_u32::<LittleEndian>()?;
-                        let value = value & 0xFFFFFF;
-                        cursor.seek(SeekFrom::Current(-1))?;
-                        decode_color(value, format)
-                    }
-                    2 | 3 | 4 | 5 => decode_color(cursor.read_u16::<LittleEndian>()? as u32, format),
-                    6 | 7 | 8 | 9 => decode_color(cursor.read_u8()? as u32, format),
-                    _ => decode_color(0, format),
-                };
-                bmp[output_index..output_index + 4].copy_from_slice(&color[..]);
-            }
-        }
-    }
-    Ok(bmp)
-}
-
-fn decode_pixel_data(data: &[u8], width: usize, height: usize, format: u32) -> Result<Vec<u8>> {
-    match format {
-        0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 => {
-            decode_rgba_pixel_data(data, width, height, format)
-        }
-        12 | 13 => etc1::decompress(data, width, height, format == 13),
-        _ => Err(Error::new(ErrorKind::Other, "Unsupported texture format.")),
-    }
 }
 
 pub fn read(file: &[u8]) -> Result<Vec<Texture>> {
@@ -246,7 +88,7 @@ pub fn read(file: &[u8]) -> Result<Vec<Texture>> {
         let pixel_format = reader.read_u32::<LittleEndian>()?;
 
         reader.seek(SeekFrom::Start(data_offset.into()))?;
-        let mut pixel_data: Vec<u8> = vec![0; (get_pixel_format_bpp(pixel_format) * width as f32 * height as f32) as usize];
+        let mut pixel_data: Vec<u8> = vec![0; (texture_decoder::get_pixel_format_bpp(pixel_format) * width as f32 * height as f32) as usize];
         reader.read_exact(&mut pixel_data)?;
         bch.push(Texture {
             filename,
@@ -260,9 +102,6 @@ pub fn read(file: &[u8]) -> Result<Vec<Texture>> {
 }
 
 fn read_header(reader: &mut Cursor<&[u8]>) -> Result<Header> {
-    let mut raw_ext_address = 0;
-    let mut raw_ext_length = 0;
-
     let magic_id = reader.read_u32::<LittleEndian>()?;
     if magic_id != 0x484342 {
         return Err(Error::new(ErrorKind::Other, "Invalid magic number."));
@@ -274,17 +113,13 @@ fn read_header(reader: &mut Cursor<&[u8]>) -> Result<Header> {
     let strings_address = reader.read_u32::<LittleEndian>()?;
     let commands_address = reader.read_u32::<LittleEndian>()?;
     let raw_data_address = reader.read_u32::<LittleEndian>()?;
-    if backward_compatibility > 0x20 {
-        raw_ext_address = reader.read_u32::<LittleEndian>()?;
-    }
+    let raw_ext_address = if backward_compatibility > 20 {reader.read_u32::<LittleEndian>()?} else {0};
     let relocation_address = reader.read_u32::<LittleEndian>()?;
     let contents_length = reader.read_u32::<LittleEndian>()?;
     let strings_length = reader.read_u32::<LittleEndian>()?;
     let commands_length = reader.read_u32::<LittleEndian>()?;
     let raw_data_length = reader.read_u32::<LittleEndian>()?;
-    if backward_compatibility > 0x20 {
-        raw_ext_length = reader.read_u32::<LittleEndian>()?;
-    }
+    let raw_ext_length = if backward_compatibility > 20 {reader.read_u32::<LittleEndian>()?} else {0};
     let relocation_length = reader.read_u32::<LittleEndian>()?;
     let uninit_data_length = reader.read_u32::<LittleEndian>()?;
     let uninit_commands_length = reader.read_u32::<LittleEndian>()?;
@@ -322,16 +157,6 @@ fn read_content_table(reader: &mut Cursor<&[u8]>, contents_address: u32) -> Resu
     })
 }
 
-fn get_pixel_format_bpp(pixel_format: u32) -> f32 {
-    match pixel_format {
-        0x0 => 4.0,
-        0x1 => 3.0,
-        0x2 | 0x3 | 0x4 | 0x5 => 2.0,
-        0x6 | 0x7 | 0x8 | 0x9 | 0xB | 0xD => 1.0,
-        0xA | 0xC => 0.5,
-        _ => 0.0,
-    }
-}
 
 #[pymethods]
 impl Texture {
@@ -359,7 +184,7 @@ impl Texture {
 impl Texture {
     pub fn decode(&self) -> Result<Self> {
         let decoded_pixel_data =
-            decode_pixel_data(&self.pixel_data, self.width, self.height, self.pixel_format)?;
+        texture_decoder::decode_pixel_data(&self.pixel_data, self.width, self.height, self.pixel_format)?;
         Ok(Texture {
             filename: self.filename.clone(),
             width: self.width,

--- a/src/bch.rs
+++ b/src/bch.rs
@@ -113,13 +113,21 @@ fn read_header(reader: &mut Cursor<&[u8]>) -> Result<Header> {
     let strings_address = reader.read_u32::<LittleEndian>()?;
     let commands_address = reader.read_u32::<LittleEndian>()?;
     let raw_data_address = reader.read_u32::<LittleEndian>()?;
+<<<<<<< HEAD
     let raw_ext_address = if backward_compatibility > 20 {reader.read_u32::<LittleEndian>()?} else {0};
+=======
+    let raw_ext_address = if backward_compatibility {reader.read_u32::<LittleEndian>()?} else {0};
+>>>>>>> b7fb863... Inline if/else for bch
     let relocation_address = reader.read_u32::<LittleEndian>()?;
     let contents_length = reader.read_u32::<LittleEndian>()?;
     let strings_length = reader.read_u32::<LittleEndian>()?;
     let commands_length = reader.read_u32::<LittleEndian>()?;
     let raw_data_length = reader.read_u32::<LittleEndian>()?;
+<<<<<<< HEAD
     let raw_ext_length = if backward_compatibility > 20 {reader.read_u32::<LittleEndian>()?} else {0};
+=======
+    let raw_ext_length = if backward_compatibility > 0x20 {reader.read_u32::<LittleEndian>()?} else {0};
+>>>>>>> b7fb863... Inline if/else for bch
     let relocation_length = reader.read_u32::<LittleEndian>()?;
     let uninit_data_length = reader.read_u32::<LittleEndian>()?;
     let uninit_commands_length = reader.read_u32::<LittleEndian>()?;

--- a/src/cgfx.rs
+++ b/src/cgfx.rs
@@ -1,0 +1,260 @@
+use crate::texture_decoder;
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::prelude::BufRead;
+use std::io::{Cursor, Result, Seek, SeekFrom, Error, ErrorKind, Read};
+use encoding_rs::UTF_8;
+use pyo3::prelude::*;
+// Source: https://www.3dbrew.org/wiki/CGFX
+
+#[allow(dead_code)]
+struct Header {
+    magic_id: u32,
+    byte_order_mark: u16,
+    struct_size: u16,
+    revision: u32,
+    file_size: u32,
+    entry_count: u32
+}
+
+impl Header {
+    fn new(reader: &mut Cursor<&[u8]>) -> Result<Self> {
+        let magic_id = reader.read_u32::<LittleEndian>()?;
+        if magic_id != 0x58464743 {
+            return Err(Error::new(ErrorKind::Other, "Invalid magic number."));
+        }
+        let byte_order_mark = reader.read_u16::<LittleEndian>()?;   // Redudant
+        let struct_size = reader.read_u16::<LittleEndian>()?;
+        let revision = reader.read_u32::<LittleEndian>()?;
+        let file_size = reader.read_u32::<LittleEndian>()?;
+        let entry_count = reader.read_u32::<LittleEndian>()?;
+
+        Ok(Header {
+            magic_id,
+            byte_order_mark,
+            struct_size,
+            revision,
+            file_size,
+            entry_count
+        })
+    }
+}
+
+#[allow(dead_code)]
+struct DATA {
+    magic_id: u32,
+    struct_size: u32,
+    entry: Vec<DATAEntry>
+}
+
+impl DATA {
+    fn new(reader: &mut Cursor<&[u8]>) -> Result<Self> {
+        let magic_id = reader.read_u32::<LittleEndian>()?;
+        let struct_size = reader.read_u32::<LittleEndian>()?;
+        let mut entry: Vec<DATAEntry> = Vec::new();
+        for _i in 0..16 {
+            let entry_count = reader.read_u32::<LittleEndian>()?;
+            let offset = reader.position() as u32 + reader.read_u32::<LittleEndian>()?;
+            entry.push(DATAEntry {
+                entry_count,
+                offset
+            });
+        }
+        Ok(DATA {
+            magic_id,
+            struct_size,
+            entry
+        })
+    }
+}
+
+#[allow(dead_code)]
+struct DATAEntry {
+    entry_count: u32,
+    offset: u32,
+}
+
+#[allow(dead_code)]
+struct DICT {
+    magic_id: u32,
+    struct_size: u32,
+    entry_count: u32,
+    entry: Vec<DICTEntry>
+}
+
+impl DICT {
+    fn new(reader: &mut Cursor<&[u8]>) -> Result<Self> {
+        let magic_id = reader.read_u32::<LittleEndian>()?;
+        let struct_size = reader.read_u32::<LittleEndian>()?;
+        let entry_count = reader.read_u32::<LittleEndian>()?;
+        reader.seek(SeekFrom::Current(0x10))?;
+        let mut entry: Vec<DICTEntry> = Vec::new();
+        for _i in 0..entry_count {
+            reader.seek(SeekFrom::Current(0x8))?;
+            let filename_offset = reader.position() as u32 + reader.read_u32::<LittleEndian>()?;
+            let object_offset = reader.position() as u32 + reader.read_u32::<LittleEndian>()?;
+            entry.push(DICTEntry {
+                filename_offset,
+                object_offset
+            })
+        }
+        Ok(DICT {
+            magic_id,
+            struct_size,
+            entry_count,
+            entry
+        })
+    }
+}
+
+#[allow(dead_code)]
+struct DICTEntry {
+    filename_offset: u32,
+    object_offset: u32,
+}
+
+// Binary Texture
+#[allow(dead_code)]
+struct TXOB {
+    flags: u32,
+    magic_id: u32,
+    filename_offset: u32,
+    height: usize,
+    width: usize,
+    mipmap_levels: u32,
+    pixel_format: u32,
+    size: usize,
+    texture_offset: u32,
+}
+
+impl TXOB {
+    fn new(reader: &mut Cursor<&[u8]>, dict: DICT) -> Result<Vec<TXOB>> {
+        let mut txob: Vec<TXOB> = Vec::new();
+        for i in 0.. dict.entry_count as usize {
+            reader.seek(SeekFrom::Start(dict.entry[i].object_offset as u64))?;
+            let flags = reader.read_u32::<LittleEndian>()?;
+            let magic_id = reader.read_u32::<LittleEndian>()?;
+            reader.seek(SeekFrom::Current(0x4))?;
+            let filename_offset = reader.position() as u32 + reader.read_u32::<LittleEndian>()?;
+            reader.seek(SeekFrom::Current(0x8))?;
+            let height = reader.read_u32::<LittleEndian>()? as usize;
+            let width = reader.read_u32::<LittleEndian>()? as usize;
+            reader.seek(SeekFrom::Current(0x8))?;
+            let mipmap_levels = reader.read_u32::<LittleEndian>()?;
+            reader.seek(SeekFrom::Current(0x8))?;
+            let pixel_format = reader.read_u32::<LittleEndian>()?;
+            reader.seek(SeekFrom::Current(0xC))?;
+            let size = reader.read_u32::<LittleEndian>()? as usize;
+            let texture_offset = reader.position() as u32 + reader.read_u32::<LittleEndian>()?;
+            txob.push(TXOB {
+                flags,
+                magic_id,
+                filename_offset,
+                height,
+                width,
+                mipmap_levels,
+                pixel_format,
+                size,
+                texture_offset
+            });
+        }
+        Ok(txob)
+    }
+}
+
+#[allow(dead_code)]
+#[pyclass(module = "fefeditor2")]
+pub struct Texture {
+    pub filename: String,
+    pub width: usize,
+    pub height: usize,
+    pub pixel_data: Vec<u8>,
+    pub pixel_format: u32,
+}
+
+impl Texture {
+    pub fn decode(&self) -> Result<Self> {
+        let decoded_pixel_data =
+        texture_decoder::decode_pixel_data(&self.pixel_data, self.width, self.height, self.pixel_format)?;
+        Ok(Texture {
+            filename: self.filename.clone(),
+            width: self.width,
+            height: self.height,
+            pixel_data: decoded_pixel_data,
+            pixel_format: self.pixel_format,
+        })
+    }
+}
+
+#[pymethods]
+impl Texture {
+    fn get_filename(&self) -> &str {
+        &self.filename
+    }
+
+    fn get_width(&self) -> usize {
+        self.width
+    }
+
+    fn get_height(&self) -> usize {
+        self.height
+    }
+
+    fn get_pixel_data(&self) -> &[u8] {
+        &self.pixel_data
+    }
+
+    fn get_pixel_format(&self) -> u32 {
+        self.pixel_format
+    }
+}
+
+impl Texture {
+    fn new(reader: &mut Cursor<&[u8]>, txob: Vec<TXOB>) -> Result<Vec<Texture>> {
+        let mut textures: Vec<Texture> = Vec::new();
+        // Read pixel data
+        for txob_file in txob {
+            let mut pixel_data: Vec<u8> = vec![0; txob_file.size];
+            reader.seek(SeekFrom::Start(txob_file.texture_offset as u64))?;
+            reader.read_exact(&mut pixel_data)?;
+    
+            // Read filename
+            reader.seek(SeekFrom::Start(txob_file.filename_offset as u64))?;
+            let mut filename_buffer: Vec<u8> = Vec::new();
+            reader.read_until(0x0, &mut filename_buffer)?;
+            filename_buffer.pop(); // Get rid of the null terminator.
+            let (result, _, errors) = UTF_8.decode(filename_buffer.as_slice());
+            if errors {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "Failed to decode utf-8 string.",
+                ));
+            }
+            let filename: String = result.into();
+            let width = txob_file.width;
+            let height = txob_file.height;
+            let pixel_format = txob_file.pixel_format;
+            textures.push(Texture {
+                filename,
+                width,
+                height,
+                pixel_data,
+                pixel_format
+            });
+        }
+        Ok(textures)
+    }
+}
+
+pub fn read(file: &[u8]) -> Result<Vec<Texture>> {
+    let mut reader = Cursor::new(file);
+    
+    let _header = Header::new(&mut reader)?;
+    let data = DATA::new(&mut reader)?;
+
+    // Going to skip a recursive loop of DICT and just access the texture entry;
+    reader.seek(SeekFrom::Start(data.entry[1].offset as u64))?;
+    let dict = DICT::new(&mut reader)?;
+    let txob = TXOB::new(&mut reader, dict)?;
+    let texture = Texture::new(&mut reader, txob)?;
+    Ok(texture)
+}

--- a/src/ctpk.rs
+++ b/src/ctpk.rs
@@ -3,7 +3,9 @@ use byteorder::{LittleEndian, ReadBytesExt};
 use std::io::prelude::BufRead;
 use std::io::{Cursor, Result, Seek, SeekFrom, Error, ErrorKind, Read};
 use encoding_rs::UTF_8;
+use pyo3::prelude::*;
 
+#[allow(dead_code)]
 pub struct Header {
     pub magic_id: u32,
     pub version: u16,
@@ -12,6 +14,28 @@ pub struct Header {
     pub texture_length: u32,
     pub hash_ptr: u32,
     pub texture_short_info_ptr: u32,
+}
+
+impl Header {
+    pub fn new(reader: &mut Cursor<&[u8]>) -> Result<Self> {
+        let magic_id = reader.read_u32::<LittleEndian>()?;
+        let version = reader.read_u16::<LittleEndian>()?;
+        let texture_count = reader.read_u16::<LittleEndian>()?;
+        let texture_ptr = reader.read_u32::<LittleEndian>()?;
+        let texture_length = reader.read_u32::<LittleEndian>()?;
+        let hash_ptr = reader.read_u32::<LittleEndian>()?;
+        let texture_short_info_ptr = reader.read_u32::<LittleEndian>()?;
+        reader.seek(SeekFrom::Current(0x8))?;    // Skip padding
+        Ok(Header {
+            magic_id,
+            version,
+            texture_count,
+            texture_ptr,
+            texture_length,
+            hash_ptr,
+            texture_short_info_ptr,
+        })
+    }
 }
 
 pub struct TextureInfo {
@@ -28,6 +52,37 @@ pub struct TextureInfo {
     pub file_time: u32,
 }
 
+impl TextureInfo {
+    fn new(reader: &mut Cursor<&[u8]>) -> Result<Self> {
+        let filename_ptr = reader.read_u32::<LittleEndian>()?;
+        let texture_length = reader.read_u32::<LittleEndian>()?;
+        let texture_ptr = reader.read_u32::<LittleEndian>()?;
+        let pixel_format = reader.read_u32::<LittleEndian>()?;
+        let width = reader.read_u16::<LittleEndian>()? as usize;
+        let height = reader.read_u16::<LittleEndian>()? as usize;
+        let mipmap_level = reader.read_u8()?;
+        let texture_type = reader.read_u8()?;
+        let cube_dir = reader.read_u16::<LittleEndian>()?;
+        let bitmap_size_ptr = reader.read_u32::<LittleEndian>()?;
+        let file_time = reader.read_u32::<LittleEndian>()?;
+        Ok(TextureInfo {
+            filename_ptr,
+            texture_length,
+            texture_ptr,
+            pixel_format,
+            width,
+            height,
+            mipmap_level,
+            texture_type,
+            cube_dir,
+            bitmap_size_ptr,
+            file_time
+        })
+    }
+}
+
+#[allow(dead_code)]
+#[pyclass(module = "fefeditor2")]
 pub struct Texture {
     pub filename: String,
     pub width: usize,
@@ -36,22 +91,59 @@ pub struct Texture {
     pub pixel_format: u32,
 }
 
+impl Texture {
+    pub fn decode(&self) -> Result<Self> {
+        let decoded_pixel_data =
+        texture_decoder::decode_pixel_data(&self.pixel_data, self.width, self.height, self.pixel_format)?;
+        Ok(Texture {
+            filename: self.filename.clone(),
+            width: self.width,
+            height: self.height,
+            pixel_data: decoded_pixel_data,
+            pixel_format: self.pixel_format,
+        })
+    }
+}
+
+#[pymethods]
+impl Texture {
+    fn get_filename(&self) -> &str {
+        &self.filename
+    }
+
+    fn get_width(&self) -> usize {
+        self.width
+    }
+
+    fn get_height(&self) -> usize {
+        self.height
+    }
+
+    fn get_pixel_data(&self) -> &[u8] {
+        &self.pixel_data
+    }
+
+    fn get_pixel_format(&self) -> u32 {
+        self.pixel_format
+    }
+}
+
 pub fn read(file: &[u8]) -> Result<Vec<Texture>> {
     let mut reader = Cursor::new(file);
 
-    let header = read_header(&mut reader)?;
+    let header = Header::new(&mut reader)?;
 
     // Read texture info
     let mut texture_info: Vec<TextureInfo> = Vec::new(); 
-    for i in 0..header.texture_count {
-        texture_info.push( read_texture_info(&mut reader)?);   
+    for _ in 0..header.texture_count {
+        texture_info.push( TextureInfo::new(&mut reader)?);   
     }
 
     // Read texture
     let mut texture: Vec<Texture> = Vec::new();
     for i in 0..header.texture_count as usize {
         // Read filename
-        reader.seek(SeekFrom::Start(texture_info[i].filename_ptr as u64));
+        reader.seek(SeekFrom::Start(texture_info[i].filename_ptr as u64))?;
         let mut filename_buffer: Vec<u8> = Vec::new();
         reader.read_until(0x0, &mut filename_buffer)?;
         filename_buffer.pop(); // Get rid of the null terminator.
@@ -65,9 +157,9 @@ pub fn read(file: &[u8]) -> Result<Vec<Texture>> {
         let filename: String = result.into();
 
         // Read pixel data
-        reader.seek(SeekFrom::Start((header.texture_ptr + texture_info[i].texture_ptr) as u64));
+        reader.seek(SeekFrom::Start((header.texture_ptr + texture_info[i].texture_ptr) as u64))?;
         let mut pixel_data: Vec<u8> = vec![0; (texture_decoder::get_pixel_format_bpp(texture_info[i].pixel_format) * texture_info[i].width as f32 * texture_info[i].height as f32) as usize];
-        reader.read_exact(&mut pixel_data);
+        reader.read_exact(&mut pixel_data)?;
 
         let width = texture_info[i].width;
         let height = texture_info[i].height;
@@ -82,51 +174,4 @@ pub fn read(file: &[u8]) -> Result<Vec<Texture>> {
     }
    Ok(texture)
 
-}
-
-fn read_header(reader: &mut Cursor<&[u8]>) -> Result<Header> {
-    let magic_id = reader.read_u32::<LittleEndian>()?;
-    let version = reader.read_u16::<LittleEndian>()?;
-    let texture_count = reader.read_u16::<LittleEndian>()?;
-    let texture_ptr = reader.read_u32::<LittleEndian>()?;
-    let texture_length = reader.read_u32::<LittleEndian>()?;
-    let hash_ptr = reader.read_u32::<LittleEndian>()?;
-    let texture_short_info_ptr = reader.read_u32::<LittleEndian>()?;
-    reader.seek(SeekFrom::Current(0x8));    // Skip padding
-    Ok(Header {
-        magic_id,
-        version,
-        texture_count,
-        texture_ptr,
-        texture_length,
-        hash_ptr,
-        texture_short_info_ptr,
-    })
-}
-
-fn read_texture_info(reader: &mut Cursor<&[u8]>) -> Result<TextureInfo> {
-    let filename_ptr = reader.read_u32::<LittleEndian>()?;
-    let texture_length = reader.read_u32::<LittleEndian>()?;
-    let texture_ptr = reader.read_u32::<LittleEndian>()?;
-    let pixel_format = reader.read_u32::<LittleEndian>()?;
-    let width = reader.read_u32::<LittleEndian>()? as usize;
-    let height = reader.read_u32::<LittleEndian>()? as usize;
-    let mipmap_level = reader.read_u8()?;
-    let texture_type = reader.read_u8()?;
-    let cube_dir = reader.read_u16::<LittleEndian>()?;
-    let bitmap_size_ptr = reader.read_u32::<LittleEndian>()?;
-    let file_time = reader.read_u32::<LittleEndian>()?;
-    Ok(TextureInfo {
-        filename_ptr,
-        texture_length,
-        texture_ptr,
-        pixel_format,
-        width,
-        height,
-        mipmap_level,
-        texture_type,
-        cube_dir,
-        bitmap_size_ptr,
-        file_time
-    })
 }

--- a/src/ctpk.rs
+++ b/src/ctpk.rs
@@ -1,0 +1,132 @@
+use crate::texture_decoder;
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::prelude::BufRead;
+use std::io::{Cursor, Result, Seek, SeekFrom, Error, ErrorKind, Read};
+use encoding_rs::UTF_8;
+
+pub struct Header {
+    pub magic_id: u32,
+    pub version: u16,
+    pub texture_count: u16,
+    pub texture_ptr: u32,
+    pub texture_length: u32,
+    pub hash_ptr: u32,
+    pub texture_short_info_ptr: u32,
+}
+
+pub struct TextureInfo {
+    pub filename_ptr: u32,
+    pub texture_length: u32,
+    pub texture_ptr: u32,
+    pub pixel_format: u32,
+    pub width: usize,
+    pub height: usize,
+    pub mipmap_level: u8,
+    pub texture_type: u8,
+    pub cube_dir: u16,
+    pub bitmap_size_ptr: u32,
+    pub file_time: u32,
+}
+
+pub struct Texture {
+    pub filename: String,
+    pub width: usize,
+    pub height: usize,
+    pub pixel_data: Vec<u8>,
+    pub pixel_format: u32,
+}
+
+pub fn read(file: &[u8]) -> Result<Vec<Texture>> {
+    let mut reader = Cursor::new(file);
+
+    let header = read_header(&mut reader)?;
+
+    // Read texture info
+    let mut texture_info: Vec<TextureInfo> = Vec::new(); 
+    for i in 0..header.texture_count {
+        texture_info.push( read_texture_info(&mut reader)?);   
+    }
+
+    // Read texture
+    let mut texture: Vec<Texture> = Vec::new();
+    for i in 0..header.texture_count as usize {
+        // Read filename
+        reader.seek(SeekFrom::Start(texture_info[i].filename_ptr as u64));
+        let mut filename_buffer: Vec<u8> = Vec::new();
+        reader.read_until(0x0, &mut filename_buffer)?;
+        filename_buffer.pop(); // Get rid of the null terminator.
+        let (result, _, errors) = UTF_8.decode(filename_buffer.as_slice());
+        if errors {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "Failed to decode utf-8 string.",
+            ));
+        }
+        let filename: String = result.into();
+
+        // Read pixel data
+        reader.seek(SeekFrom::Start((header.texture_ptr + texture_info[i].texture_ptr) as u64));
+        let mut pixel_data: Vec<u8> = vec![0; (texture_decoder::get_pixel_format_bpp(texture_info[i].pixel_format) * texture_info[i].width as f32 * texture_info[i].height as f32) as usize];
+        reader.read_exact(&mut pixel_data);
+
+        let width = texture_info[i].width;
+        let height = texture_info[i].height;
+        let pixel_format = texture_info[i].pixel_format;
+        texture.push(Texture {
+            filename,
+            width,
+            height,
+            pixel_data,
+            pixel_format
+        })
+    }
+   Ok(texture)
+
+}
+
+fn read_header(reader: &mut Cursor<&[u8]>) -> Result<Header> {
+    let magic_id = reader.read_u32::<LittleEndian>()?;
+    let version = reader.read_u16::<LittleEndian>()?;
+    let texture_count = reader.read_u16::<LittleEndian>()?;
+    let texture_ptr = reader.read_u32::<LittleEndian>()?;
+    let texture_length = reader.read_u32::<LittleEndian>()?;
+    let hash_ptr = reader.read_u32::<LittleEndian>()?;
+    let texture_short_info_ptr = reader.read_u32::<LittleEndian>()?;
+    reader.seek(SeekFrom::Current(0x8));    // Skip padding
+    Ok(Header {
+        magic_id,
+        version,
+        texture_count,
+        texture_ptr,
+        texture_length,
+        hash_ptr,
+        texture_short_info_ptr,
+    })
+}
+
+fn read_texture_info(reader: &mut Cursor<&[u8]>) -> Result<TextureInfo> {
+    let filename_ptr = reader.read_u32::<LittleEndian>()?;
+    let texture_length = reader.read_u32::<LittleEndian>()?;
+    let texture_ptr = reader.read_u32::<LittleEndian>()?;
+    let pixel_format = reader.read_u32::<LittleEndian>()?;
+    let width = reader.read_u32::<LittleEndian>()? as usize;
+    let height = reader.read_u32::<LittleEndian>()? as usize;
+    let mipmap_level = reader.read_u8()?;
+    let texture_type = reader.read_u8()?;
+    let cube_dir = reader.read_u16::<LittleEndian>()?;
+    let bitmap_size_ptr = reader.read_u32::<LittleEndian>()?;
+    let file_time = reader.read_u32::<LittleEndian>()?;
+    Ok(TextureInfo {
+        filename_ptr,
+        texture_length,
+        texture_ptr,
+        pixel_format,
+        width,
+        height,
+        mipmap_level,
+        texture_type,
+        cube_dir,
+        bitmap_size_ptr,
+        file_time
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub mod arc;
 pub mod bch;
 pub mod hack_file_system;
 pub mod etc1;
+pub mod texture_decoder;
+pub mod ctpk;
 
 use pyo3::prelude::*;
 use pyo3::{wrap_pyfunction, types::PyBytes};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod hack_file_system;
 pub mod etc1;
 pub mod texture_decoder;
 pub mod ctpk;
+pub mod cgfx;
 
 use pyo3::prelude::*;
 use pyo3::{wrap_pyfunction, types::PyBytes};

--- a/src/texture_decoder.rs
+++ b/src/texture_decoder.rs
@@ -167,6 +167,6 @@ pub fn get_pixel_format_bpp(pixel_format: u32) -> f32 {
         0x2 | 0x3 | 0x4 | 0x5 => 2.0,
         0x6 | 0x7 | 0x8 | 0x9 | 0xB | 0xD => 1.0,
         0xA | 0xC => 0.5,
-        _ => Err(Error::new(ErrorKind::Other, "Unsupported texture format.")),
+        _ => 0.0,
     }
 }

--- a/src/texture_decoder.rs
+++ b/src/texture_decoder.rs
@@ -1,0 +1,172 @@
+use crate::etc1;
+use std::io::{Error, ErrorKind, Seek, SeekFrom, Result, Cursor};
+use byteorder::{LittleEndian, ReadBytesExt};
+
+static CONVERT_5_TO_8: &'static [u8] = &[
+    0x00, 0x08, 0x10, 0x18, 0x20, 0x29, 0x31, 0x39, 0x41, 0x4A, 0x52, 0x5A, 0x62, 0x6A, 0x73, 0x7B,
+    0x83, 0x8B, 0x94, 0x9C, 0xA4, 0xAC, 0xB4, 0xBD, 0xC5, 0xCD, 0xD5, 0xDE, 0xE6, 0xEE, 0xF6, 0xFF,
+];
+
+static TILE_ORDER: &'static [u8] = &[
+    0, 1, 8, 9, 2, 3, 10, 11, 16, 17, 24, 25, 18, 19, 26, 27, 4, 5, 12, 13, 6, 7, 14, 15, 20, 21,
+    28, 29, 22, 23, 30, 31, 32, 33, 40, 41, 34, 35, 42, 43, 48, 49, 56, 57, 50, 51, 58, 59, 36, 37,
+    44, 45, 38, 39, 46, 47, 52, 53, 60, 61, 54, 55, 62, 63,
+];
+
+pub fn decode_color(value: u32, format: u32) -> Vec<u8> {
+    let mut color: Vec<u8> = vec![0, 0, 0, 0];
+    match format {
+        0 => {
+            // RGBA8
+            color[0] = ((value >> 24) & 0xFF) as u8;
+            color[1] = ((value >> 16) & 0xFF) as u8;
+            color[2] = ((value >> 8) & 0xFF) as u8;
+            color[3] = (value & 0xFF) as u8;
+        }
+        1 => {
+            // RGB8
+            color[0] = ((value >> 16) & 0xFF) as u8;
+            color[1] = ((value >> 8) & 0xFF) as u8;
+            color[2] = (value & 0xFF) as u8;
+            color[3] = 0xFF;
+        }
+        2 => {
+            // RGB 5551
+            color[0] = CONVERT_5_TO_8[((value >> 11) & 0x1F) as usize];
+            color[1] = CONVERT_5_TO_8[((value >> 6) & 0x1F) as usize];
+            color[2] = CONVERT_5_TO_8[((value >> 1) & 0x1F) as usize];
+            color[3] = if value & 1 == 1 { 0xFF } else { 0 };
+        }
+        3 => {
+            // RGB565
+            color[0] = CONVERT_5_TO_8[((value >> 11) & 0x1F) as usize];
+            color[1] = (((value >> 5) & 0x3F) * 4) as u8;
+            color[2] = CONVERT_5_TO_8[(value & 0x1F) as usize];
+            color[3] = 0xFF;
+        }
+        4 => {
+            // RGBA4
+            let r = (value >> 12) & 0xF;
+            let g = (value >> 8) & 0xF;
+            let b = (value >> 4) & 0xF;
+            let a = value & 0xF;
+            color[0] = (r | (r << 4)) as u8;
+            color[1] = (g | (g << 4)) as u8;
+            color[2] = (b | (b << 4)) as u8;
+            color[3] = (a | (a << 4)) as u8;
+        }
+        5 => {
+            // LA8
+            let red = ((value >> 8) & 0xFF) as u8;
+            color[0] = red;
+            color[1] = red;
+            color[2] = red;
+            color[3] = (value & 0xFF) as u8;
+        }
+        6 => {
+            // HILO8
+            let red = (value >> 8) as u8;
+            color[0] = red;
+            color[1] = red;
+            color[2] = red;
+            color[3] = 0xFF;
+        }
+        7 => {
+            // L8
+            color[0] = value as u8;
+            color[1] = value as u8;
+            color[2] = value as u8;
+            color[3] = 0xFF;
+        }
+        8 => {
+            // A8
+            color[0] = 0xFF;
+            color[1] = 0xFF;
+            color[2] = 0xFF;
+            color[3] = value as u8;
+        }
+        9 => {
+            // LA4
+            let red = (value >> 4) as u8;
+            color[0] = red;
+            color[1] = red;
+            color[2] = red;
+            color[3] = (value & 0xF) as u8;
+        }
+        10 => {
+            // L4
+            let red = (value * 0x11) as u8;
+            color[0] = red;
+            color[1] = red;
+            color[2] = red;
+            color[3] = 0xFF;
+        }
+        11 => {
+            // A4
+            color[0] = 0xFF;
+            color[1] = 0xFF;
+            color[2] = 0xFF;
+            color[3] = (value * 0x11) as u8;
+        }
+        _ => {}
+    }
+    color
+}
+
+fn decode_rgba_pixel_data(
+    data: &[u8],
+    width: usize,
+    height: usize,
+    format: u32,
+) -> Result<Vec<u8>> {
+    let num_pixels = width * height;
+    let mut bmp: Vec<u8> = Vec::new();
+    bmp.resize(4 * num_pixels, 0);
+    let mut cursor = Cursor::new(data);
+
+    for tile_y in 0..height / 8 {
+        for tile_x in 0..width / 8 {
+            for pixel in 0..64 {
+                let x = (TILE_ORDER[pixel] % 8) as usize;
+                let y = (TILE_ORDER[pixel] as usize - x) / 8;
+                let output_index = (tile_x * 8 + x + ((tile_y * 8 + y) * width)) * 4;
+            
+                let color = match format {
+                    0 => decode_color(cursor.read_u32::<LittleEndian>()?, format),
+                    1 => {
+                        let value = cursor.read_u32::<LittleEndian>()?;
+                        let value = value & 0xFFFFFF;
+                        cursor.seek(SeekFrom::Current(-1))?;
+                        decode_color(value, format)
+                    }
+                    2 | 3 | 4 | 5 => decode_color(cursor.read_u16::<LittleEndian>()? as u32, format),
+                    6 | 7 | 8 | 9 => decode_color(cursor.read_u8()? as u32, format),
+                    _ => decode_color(0, format),
+                };
+                bmp[output_index..output_index + 4].copy_from_slice(&color[..]);
+            }
+        }
+    }
+    Ok(bmp)
+}
+
+pub fn decode_pixel_data(data: &[u8], width: usize, height: usize, format: u32) -> Result<Vec<u8>> {
+    match format {
+        0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 => {
+            decode_rgba_pixel_data(data, width, height, format)
+        }
+        12 | 13 => etc1::decompress(data, width, height, format == 13),
+        _ => Err(Error::new(ErrorKind::Other, "Unsupported texture format.")),
+    }
+}
+
+pub fn get_pixel_format_bpp(pixel_format: u32) -> f32 {
+    match pixel_format {
+        0x0 => 4.0,
+        0x1 => 3.0,
+        0x2 | 0x3 | 0x4 | 0x5 => 2.0,
+        0x6 | 0x7 | 0x8 | 0x9 | 0xB | 0xD => 1.0,
+        0xA | 0xC => 0.5,
+        _ => Err(Error::new(ErrorKind::Other, "Unsupported texture format.")),
+    }
+}


### PR DESCRIPTION
- Refactored texture decoding functions from bch into texture_decoder module for cgfx and ctpk modules to access
  - ETC1 module included in texture_decoder module
- Changed arc module to return arc object instead of texture object to expose is_awakening flag
  - Added awakening support to open_arc function in hack_filesystem module
- Refactored bch
  - Implementations for structs to follow logic of original source code
- Tested cgfx and ctpk, and they work. bch and arc modules both still work after refactoring.