### PR TITLE
 remove deprecated pydantic calls

### DIFF
--- a/paragon/model/auto_ui.py
+++ b/paragon/model/auto_ui.py
@@ -295,21 +295,21 @@ class SwappableSpec(AutoWidgetSpec):
     names: List[str]
 
 
-def update_forward_refs():
-    UISpec.update_forward_refs()
-    FormSpec.update_forward_refs()
-    WidgetSpec.update_forward_refs()
-    LabelSpec.update_forward_refs()
-    VBoxSpec.update_forward_refs()
-    HBoxSpec.update_forward_refs()
-    GroupBoxSpec.update_forward_refs()
-    ScrollSpec.update_forward_refs()
-    CollapsibleSpec.update_forward_refs()
-    TabsSpec.update_forward_refs()
-    TabSpec.update_forward_refs()
-    GridCellSpec.update_forward_refs()
-    GridSpec.update_forward_refs()
-    SwappableSpec.update_forward_refs()
+def model_rebuild():
+    UISpec.model_rebuild()
+    FormSpec.model_rebuild()
+    WidgetSpec.model_rebuild()
+    LabelSpec.model_rebuild()
+    VBoxSpec.model_rebuild()
+    HBoxSpec.model_rebuild()
+    GroupBoxSpec.model_rebuild()
+    ScrollSpec.model_rebuild()
+    CollapsibleSpec.model_rebuild()
+    TabsSpec.model_rebuild()
+    TabSpec.model_rebuild()
+    GridCellSpec.model_rebuild()
+    GridSpec.model_rebuild()
+    SwappableSpec.model_rebuild()
 
 
 AnyTopLevelSpec = Union[

--- a/paragon/ui/specs.py
+++ b/paragon/ui/specs.py
@@ -15,7 +15,7 @@ class Specs:
     @staticmethod
     def load(path, language):
         language_dir = os.path.join(path, language.value)
-        auto_ui.update_forward_refs()
+        auto_ui.model_rebuild()
         specs = Specs._load_specs_from_dir(path)
         if os.path.exists(language_dir):
             specs.update(Specs._load_specs_from_dir(language_dir))


### PR DESCRIPTION
    Previously, opening a project resulted in:

    `AttributeError: Attribute '__signature__' of 'ModelMetaclass' object is not writable`

    Likely caused by the fact that `update_forward_refs` is deprecated in
    pydantic.

    Replaced with `model_rebuild` as per pydantic suggestion.